### PR TITLE
Minor clipping bug fix

### DIFF
--- a/torchstain/normalizers/numpy_macenko_normalizer.py
+++ b/torchstain/normalizers/numpy_macenko_normalizer.py
@@ -106,7 +106,7 @@ class NumpyMacenkoNormalizer(HENormalizer):
 
         # recreate the image using reference mixing matrix
         Inorm = np.multiply(Io, np.exp(-self.HERef.dot(C2)))
-        Inorm[Inorm > 255] = 254
+        Inorm[Inorm > 255] = 255
         Inorm = np.reshape(Inorm.T, (h, w, c)).astype(np.uint8)
 
 
@@ -115,11 +115,11 @@ class NumpyMacenkoNormalizer(HENormalizer):
         if stains:
             # unmix hematoxylin and eosin
             H = np.multiply(Io, np.exp(np.expand_dims(-self.HERef[:,0], axis=1).dot(np.expand_dims(C2[0,:], axis=0))))
-            H[H>255] = 254
+            H[H > 255] = 255
             H = np.reshape(H.T, (h, w, c)).astype(np.uint8)
 
             E = np.multiply(Io, np.exp(np.expand_dims(-self.HERef[:,1], axis=1).dot(np.expand_dims(C2[1,:], axis=0))))
-            E[E>255] = 254
+            E[E > 255] = 255
             E = np.reshape(E.T, (h, w, c)).astype(np.uint8)
 
         return Inorm, H, E

--- a/torchstain/normalizers/torch_macenko_normalizer.py
+++ b/torchstain/normalizers/torch_macenko_normalizer.py
@@ -107,18 +107,18 @@ class TorchMacenkoNormalizer(HENormalizer):
 
         # recreate the image using reference mixing matrix
         Inorm = Io * torch.exp(-torch.matmul(self.HERef, C))
-        Inorm[Inorm > 255] = 254
+        Inorm[Inorm > 255] = 255
         Inorm = Inorm.T.reshape(h, w, c).int()
 
         H, E = None, None
 
         if stains:
             H = torch.mul(Io, torch.exp(torch.matmul(-self.HERef[:, 0].unsqueeze(-1), C[0, :].unsqueeze(0))))
-            H[H > 255] = 254
+            H[H > 255] = 255
             H = H.T.reshape(h, w, c).int()
 
             E = torch.mul(Io, torch.exp(torch.matmul(-self.HERef[:, 1].unsqueeze(-1), C[1, :].unsqueeze(0))))
-            E[E > 255] = 254
+            E[E > 255] = 255
             E = E.T.reshape(h, w, c).int()
 
         return Inorm, H, E


### PR DESCRIPTION
I believe there was a bug related to when a clipping operation is applied before casting to uint8. The wrong value (254) was assigned to the values higher than the natural limit of uint8 (255).

The same bug was observed for both the Macenko and the Numpy implementations.