### PR TITLE
Fixed RGB/LAB unit test

### DIFF
--- a/tests/test_color_conv.py
+++ b/tests/test_color_conv.py
@@ -4,12 +4,16 @@ import numpy as np
 import cv2
 import os
 
-def test_rgb_to_lab():
+def test_rgb_lab():
     size = 1024
     curr_file_path = os.path.dirname(os.path.realpath(__file__))
     img = cv2.resize(cv2.cvtColor(cv2.imread(os.path.join(curr_file_path, "../data/source.png")), cv2.COLOR_BGR2RGB), (size, size))
+    
+    # rgb2lab expects data to be float32 in range [0, 1]
+    img = img / 255
 
+    # convert from RGB to LAB and back again to RGB
     reconstructed_img = lab2rgb(rgb2lab(img))
-    val = np.mean(np.abs(reconstructed_img - img))
-    print("MAE:", val)
-    assert val < 0.1
+
+    # assess if the reconstructed image is similar to the original image
+    np.testing.assert_almost_equal(np.mean(np.abs(reconstructed_img - img)), 0.0, decimal=4, verbose=True)


### PR DESCRIPTION
This unit tests checks whether converting from RGB to LAB and back to RGB yield negligible reconstruction loss.

Before next release we should add more documentation on all classes and methods.