### PR TITLE
Add modified reinhard support

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,9 @@
 GPU-accelerated stain normalization tools for histopathological images. Compatible with PyTorch, TensorFlow, and Numpy.
 Normalization algorithms currently implemented:
 
-- Macenko et al. [\[1\]](#reference) (ported from [numpy implementation](https://github.com/schaugf/HEnorm_python))
-- Reinhard et al. [\[2\]](#reference)
+- Macenko [\[1\]](#reference) (ported from [numpy implementation](https://github.com/schaugf/HEnorm_python))
+- Reinhard [\[2\]](#reference)
+- Modified Reinhard [\[3\]](#reference)
 
 ## Installation
 
@@ -50,6 +51,7 @@ norm, H, E = normalizer.normalize(I=t_to_transform, stains=True)
 |-|-|-|-|
 | Macenko | &check; | &check; | &check; |
 | Reinhard | &check; | &check; | &check; |
+| Modified Reinhard | &check; | &check; | &check; |
 
 ## Backend comparison
 
@@ -68,8 +70,9 @@ Results with 10 runs per size on a Intel(R) Core(TM) i5-8365U CPU @ 1.60GHz
 
 ## Reference
 
-- [1] Macenko, Marc, et al. "A method for normalizing histology slides for quantitative analysis." 2009 IEEE International Symposium on Biomedical Imaging: From Nano to Macro. IEEE, 2009.
-- [2] Reinhard, Erik, et al. "Color transfer between images." IEEE Computer Graphics and Applications. IEEE, 2001.
+- [1] Macenko, Marc et al. "A method for normalizing histology slides for quantitative analysis." 2009 IEEE International Symposium on Biomedical Imaging: From Nano to Macro. IEEE, 2009.
+- [2] Reinhard, Erik et al. "Color transfer between images." IEEE Computer Graphics and Applications. IEEE, 2001.
+- [3] Roy, Santanu et al. "Modified Reinhard Algorithm for Color Normalization of Colorectal Cancer Histopathology Images". 2021 29th European Signal Processing Conference (EUSIPCO), IEEE, 2021.
 
 ## Citing
 

--- a/torchstain/base/normalizers/reinhard.py
+++ b/torchstain/base/normalizers/reinhard.py
@@ -1,12 +1,12 @@
-def ReinhardNormalizer(backend='numpy'):
+def ReinhardNormalizer(backend='numpy', method=None):
     if backend == 'numpy':
         from torchstain.numpy.normalizers import NumpyReinhardNormalizer
-        return NumpyReinhardNormalizer()
+        return NumpyReinhardNormalizer(method=method)
     elif backend == "torch":
         from torchstain.torch.normalizers import TorchReinhardNormalizer
-        return TorchReinhardNormalizer()
+        return TorchReinhardNormalizer(method=method)
     elif backend == "tensorflow":
         from torchstain.tf.normalizers import TensorFlowReinhardNormalizer
-        return TensorFlowReinhardNormalizer()
+        return TensorFlowReinhardNormalizer(method=method)
     else:
         raise Exception(f'Unknown backend {backend}')

--- a/torchstain/numpy/normalizers/reinhard.py
+++ b/torchstain/numpy/normalizers/reinhard.py
@@ -11,8 +11,9 @@ https://github.com/DigitalSlideArchive/HistomicsTK/blob/master/histomicstk/prepr
 https://github.com/Peter554/StainTools/blob/master/staintools/reinhard_color_normalizer.py
 """
 class NumpyReinhardNormalizer(HENormalizer):
-    def __init__(self):
+    def __init__(self, method=None):
         super().__init__()
+        self.method = method
         self.target_mus = None
         self.target_stds = None
     
@@ -41,9 +42,26 @@ class NumpyReinhardNormalizer(HENormalizer):
         mus = stack_[:, 0]
         stds = stack_[:, 1]
 
-        # standardize intensities channel-wise and normalize using target mus and stds
-        result = [standardize(x, mu_, std_) * std_T + mu_T for x, mu_, std_, mu_T, std_T \
-            in zip(labs, mus, stds, self.target_means, self.target_stds)]
+        # normalize
+        if self.method is None:
+            # standardize intensities channel-wise and normalize using target mus and stds
+            result = [standardize(x, mu_, std_) * std_T + mu_T for x, mu_, std_, mu_T, std_T \
+                in zip(labs, mus, stds, self.target_means, self.target_stds)]
+
+        elif self.method == "modified":
+            # calculate q
+            q = (self.target_stds[0] - stds[0]) / self.target_stds[0]
+            q = 0.05 if q <= 0 else q
+
+            # normalize each channel independently
+            l_norm = mus[0] + (labs[0] - mus[0]) * (1 + q)
+            a_norm = self.target_means[1] + (labs[1] - mus[1])
+            b_norm = self.target_means[2] + (labs[2] - mus[2])
+
+            result = [l_norm, a_norm, b_norm]
+
+        else:
+            raise ValueError("Unsupported 'method' was chosen. Choose either {None, 'modified'}.")
         
         # rebuild LAB
         lab = lab_merge(*result)

--- a/torchstain/torch/normalizers/reinhard.py
+++ b/torchstain/torch/normalizers/reinhard.py
@@ -11,8 +11,9 @@ https://github.com/DigitalSlideArchive/HistomicsTK/blob/master/histomicstk/prepr
 https://github.com/Peter554/StainTools/blob/master/staintools/reinhard_color_normalizer.py
 """
 class TorchReinhardNormalizer(HENormalizer):
-    def __init__(self):
+    def __init__(self, method=None):
         super().__init__()
+        self.method = method
         self.target_mus = None
         self.target_stds = None
     
@@ -41,9 +42,26 @@ class TorchReinhardNormalizer(HENormalizer):
         mus = stack_[:, 0]
         stds = stack_[:, 1]
 
-        # standardize intensities channel-wise and normalize using target mus and stds
-        result = [standardize(x, mu_, std_) * std_T + mu_T for x, mu_, std_, mu_T, std_T \
-            in zip(labs, mus, stds, self.target_means, self.target_stds)]
+        # normalize
+        if self.method is None:
+            # standardize intensities channel-wise and normalize using target mus and stds
+            result = [standardize(x, mu_, std_) * std_T + mu_T for x, mu_, std_, mu_T, std_T \
+                in zip(labs, mus, stds, self.target_means, self.target_stds)]
+
+        elif self.method == "modified":
+            # calculate q
+            q = (self.target_stds[0] - stds[0]) / self.target_stds[0]
+            q = 0.05 if q <= 0 else q
+
+            # normalize each channel independently
+            l_norm = mus[0] + (labs[0] - mus[0]) * (1 + q)
+            a_norm = self.target_means[1] + (labs[1] - mus[1])
+            b_norm = self.target_means[2] + (labs[2] - mus[2])
+
+            result = [l_norm, a_norm, b_norm]
+
+        else:
+            raise ValueError("Unsupported 'method' was chosen. Choose either {None, 'modified'}.")
         
         # rebuild LAB
         lab = lab_merge(*result)


### PR DESCRIPTION
This PR extends Reinhard and adds a new method argument, which enables the user to choose between traditional Reinhard and the Modified version. All backends supported.

**This PR can be merged after** https://github.com/EIDOSLAB/torchstain/pull/27 **, as this branch was based on that branch.**