### PR TITLE
Fixed scaling value in torch rgb2lab

### DIFF
--- a/torchstain/torch/utils/rgb2lab.py
+++ b/torchstain/torch/utils/rgb2lab.py
@@ -25,7 +25,7 @@ def rgb2lab(rgb):
     mask = arr > 0.008856
     not_mask = torch.logical_not(mask)
     arr.masked_scatter_(mask, torch.pow(torch.masked_select(arr, mask), 1 / 3))
-    arr.masked_scatter_(not_mask, 7.787 * torch.masked_select(arr, not_mask) + 16 / 166)
+    arr.masked_scatter_(not_mask, 7.787 * torch.masked_select(arr, not_mask) + 16 / 116)
 
     # get each channel as individual tensors
     x, y, z = arr[0], arr[1], arr[2]


### PR DESCRIPTION
Fixes https://github.com/EIDOSLAB/torchstain/issues/50.

I have verified that no similar issue were in the other backends and for both rgb2lab and lab2rgb scripts.