### PR TITLE
Use shell: bash when installing wheels in CIs

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -15,8 +15,7 @@ jobs:
           python-version: '3.x'
 
       - name: Install deps
-        run: |
-          pip install setuptools wheel
+        run: pip install setuptools wheel
 
       - name: Build wheels
         run: python setup.py sdist bdist_wheel

--- a/.github/workflows/tests_full.yml
+++ b/.github/workflows/tests_full.yml
@@ -62,6 +62,7 @@ jobs:
 
       - name: Install wheel
         run: pip install --find-links=${{github.workspace}} torchstain
+        shell: bash
 
       - name: Run tests
         run: pytest -vs tests/test_tf.py
@@ -101,6 +102,7 @@ jobs:
 
       - name: Install wheel
         run: pip install --find-links=${{github.workspace}} torchstain
+        shell: bash
 
       - name: Run tests
         run: pytest -vs tests/test_torch.py

--- a/.github/workflows/tests_full.yml
+++ b/.github/workflows/tests_full.yml
@@ -56,12 +56,10 @@ jobs:
           name: "Python wheel"
 
       - name: Install dependencies
-        run: |
-          pip install tensorflow==${{ matrix.tf-version }} protobuf==3.20.* opencv-python-headless scikit-image
-          pip install pytest
+        run: pip install tensorflow==${{ matrix.tf-version }} protobuf==3.20.* opencv-python-headless scikit-image pytest
 
       - name: Install wheel
-        run: pip install --find-links=${{github.workspace}} torchstain
+        run: pip install --find-links=${{github.workspace}} torchstain-*
         shell: bash
 
       - name: Run tests
@@ -96,12 +94,10 @@ jobs:
           name: "Python wheel"
 
       - name: Install dependencies
-        run: |
-          pip install torch==${{ matrix.pytorch-version }} torchvision opencv-python-headless scikit-image
-          pip install pytest
+        run: pip install torch==${{ matrix.pytorch-version }} torchvision opencv-python-headless scikit-image pytest
 
       - name: Install wheel
-        run: pip install --find-links=${{github.workspace}} torchstain
+        run: pip install --find-links=${{github.workspace}} torchstain-*
         shell: bash
 
       - name: Run tests

--- a/.github/workflows/tests_quick.yml
+++ b/.github/workflows/tests_quick.yml
@@ -54,6 +54,7 @@ jobs:
 
       - name: Install wheel
         run: pip install --find-links=${{github.workspace}} torchstain
+        shell: bash
 
       - name: Run tests
         run: pytest -vs tests/test_tf.py
@@ -81,6 +82,7 @@ jobs:
 
       - name: Install wheel
         run: pip install --find-links=${{github.workspace}} torchstain
+        shell: bash
 
       - name: Run tests
         run: pytest -vs tests/test_torch.py

--- a/.github/workflows/tests_quick.yml
+++ b/.github/workflows/tests_quick.yml
@@ -48,12 +48,10 @@ jobs:
           name: "Python wheel"
 
       - name: Install dependencies
-        run: |
-          pip install tensorflow protobuf==3.20.* opencv-python-headless scikit-image
-          pip install pytest
+        run: pip install tensorflow protobuf==3.20.* opencv-python-headless scikit-image pytest
 
       - name: Install wheel
-        run: pip install --find-links=${{github.workspace}} torchstain
+        run: pip install --find-links=${{github.workspace}} torchstain-*
         shell: bash
 
       - name: Run tests
@@ -76,12 +74,10 @@ jobs:
           name: "Python wheel"
 
       - name: Install dependencies
-        run: |
-          pip install torch torchvision opencv-python-headless scikit-image
-          pip install pytest
+        run: pip install torch torchvision opencv-python-headless scikit-image pytest
 
       - name: Install wheel
-        run: pip install --find-links=${{github.workspace}} torchstain
+        run: pip install --find-links=${{github.workspace}} torchstain-*
         shell: bash
 
       - name: Run tests


### PR DESCRIPTION
I observed an issue with installing compiled wheels in my test CIs in [another project](https://github.com/andreped/GradientAccumulator/blob/main/.github/workflows/test.yml#L82).

Apparently, pip ignores the --file-links argument if it finds a suitable wheel with the same name on PyPI. That means that it will ignore installing from the existing local wheel, and instead download the one on PyPI and install that one. This defeats the purpose of the test, as we are not testing the correct wheel!

This was solved by adding the -* wildcard fix like so package_name-* to the command. However, that fails in Powershell (on Windows). Thus, forcing the command to run with bash works for all operating systems.